### PR TITLE
Configure npm run dev to function as API server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "build": "vite build",
     "start": "node dist/index.js",
-    "dev": "vite --mode development",
+    "dev": "vite build --watch & nodemon dist/index.js",
+    "dev:build": "vite build --watch",
+    "dev:server": "nodemon dist/index.js",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",


### PR DESCRIPTION
## Summary
• Updated `npm run dev` to work as an API server instead of just a Vite development server
• Added Vite watch build combined with nodemon for automatic server restarts on code changes
• Added additional development scripts for more granular control

## Changes
- **npm run dev**: Now runs `vite build --watch & nodemon dist/index.js` for full development workflow
- **npm run dev:build**: Runs Vite in watch mode only
- **npm run dev:server**: Runs nodemon on built files only

## Benefits
- Consistent development experience with API server functionality
- Hot reload on source code changes
- Single command to start development environment
- API documentation available at http://localhost:3000/docs

## Test plan
- [x] Verify `npm run dev` starts API server on port 3000
- [x] Test hot reload functionality with source code changes
- [x] Confirm Swagger UI accessible at /docs endpoint
- [x] Validate API filtering functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)