### PR TITLE
Add batch embedding creation endpoint for multiple text processing

### DIFF
--- a/src/routes/openapi.ts
+++ b/src/routes/openapi.ts
@@ -1,5 +1,7 @@
 import { createRoute } from "@hono/zod-openapi"
 import {
+  BatchCreateEmbeddingRequestSchema,
+  BatchCreateEmbeddingResponseSchema,
   CreateEmbeddingRequestSchema,
   CreateEmbeddingResponseSchema,
   DeleteEmbeddingResponseSchema,
@@ -173,6 +175,52 @@ export const deleteEmbeddingRoute = createRoute({
       content: {
         "application/json": {
           schema: NotFoundResponseSchema,
+        },
+      },
+    },
+    500: {
+      description: "Internal server error",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+  },
+})
+
+// Batch create embeddings
+export const createBatchEmbeddingRoute = createRoute({
+  method: "post",
+  path: "/embeddings/batch",
+  tags: ["Embeddings"],
+  summary: "Create multiple embeddings",
+  description:
+    "Generate and store embeddings for multiple text contents in a single request",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: BatchCreateEmbeddingRequestSchema,
+        },
+      },
+      description: "Batch embedding creation request",
+    },
+  },
+  responses: {
+    200: {
+      description: "Batch embedding processing completed",
+      content: {
+        "application/json": {
+          schema: BatchCreateEmbeddingResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: "Invalid request body",
+      content: {
+        "application/json": {
+          schema: ValidationErrorResponseSchema,
         },
       },
     },

--- a/src/schemas/openapi.ts
+++ b/src/schemas/openapi.ts
@@ -18,6 +18,33 @@ export const CreateEmbeddingRequestSchema = z
   })
   .openapi("CreateEmbeddingRequest")
 
+export const BatchCreateEmbeddingRequestSchema = z
+  .object({
+    texts: z
+      .array(
+        z.object({
+          uri: z.string().min(1).openapi({
+            description: "Unique identifier for the resource being embedded",
+            example: "file://document1.txt",
+          }),
+          text: z.string().min(1).openapi({
+            description: "Text content to generate embedding for",
+            example: "This is the first document content.",
+          }),
+        })
+      )
+      .min(1)
+      .max(100)
+      .openapi({
+        description: "Array of texts to process (max 100 items)",
+      }),
+    model_name: z.string().optional().default("embeddinggemma:300m").openapi({
+      description: "Name of the embedding model to use for all texts",
+      example: "embeddinggemma:300m",
+    }),
+  })
+  .openapi("BatchCreateEmbeddingRequest")
+
 export const UriParamSchema = z.object({
   uri: z.string().openapi({
     param: { name: "uri", in: "path" },
@@ -99,6 +126,51 @@ export const CreateEmbeddingResponseSchema = z
     }),
   })
   .openapi("CreateEmbeddingResponse")
+
+export const BatchCreateEmbeddingResponseSchema = z
+  .object({
+    results: z
+      .array(
+        z.object({
+          id: z.number().openapi({
+            description: "Unique identifier of the created embedding",
+            example: 123,
+          }),
+          uri: z.string().openapi({
+            description: "Resource URI",
+            example: "file://document1.txt",
+          }),
+          model_name: z.string().openapi({
+            description: "Model used for embedding generation",
+            example: "embeddinggemma:300m",
+          }),
+          status: z.enum(["success", "error"]).openapi({
+            description: "Processing status",
+            example: "success",
+          }),
+          error: z.string().optional().openapi({
+            description: "Error message if processing failed",
+            example: "Failed to generate embedding",
+          }),
+        })
+      )
+      .openapi({
+        description: "Array of processing results",
+      }),
+    total: z.number().openapi({
+      description: "Total number of texts processed",
+      example: 5,
+    }),
+    successful: z.number().openapi({
+      description: "Number of successfully processed texts",
+      example: 4,
+    }),
+    failed: z.number().openapi({
+      description: "Number of failed texts",
+      example: 1,
+    }),
+  })
+  .openapi("BatchCreateEmbeddingResponse")
 
 export const EmbeddingSchema = z
   .object({

--- a/src/types/embedding.ts
+++ b/src/types/embedding.ts
@@ -14,6 +14,27 @@ export interface CreateEmbeddingRequest {
   model_name?: string
 }
 
+export interface BatchCreateEmbeddingRequest {
+  texts: Array<{
+    uri: string
+    text: string
+  }>
+  model_name?: string
+}
+
+export interface BatchCreateEmbeddingResponse {
+  results: Array<{
+    id: number
+    uri: string
+    model_name: string
+    status: "success" | "error"
+    error?: string
+  }>
+  total: number
+  successful: number
+  failed: number
+}
+
 export interface CreateEmbeddingResponse {
   id: number
   uri: string


### PR DESCRIPTION
## Summary
• Add POST /embeddings/batch endpoint supporting up to 100 texts in single request
• Implement type-safe batch processing with individual error handling per text
• Add comprehensive Zod validation schemas for request/response structures
• Support partial success scenarios with detailed result reporting for each text
• Add complete OpenAPI documentation and Swagger integration
• Maintain Effect-based functional programming patterns throughout implementation

## Test plan
- [ ] Test batch endpoint with valid request containing multiple texts
- [ ] Test batch endpoint with invalid request (empty array, too many items)
- [ ] Test partial failure scenarios (some texts fail, others succeed)
- [ ] Verify OpenAPI documentation is correctly generated
- [ ] Test error handling for individual text processing failures
- [ ] Validate response format matches BatchCreateEmbeddingResponse schema

🤖 Generated with [Claude Code](https://claude.ai/code)