### PR TITLE
fix(core): add CommonJS require export to fix npm run dev error

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Add "require" export field to @ees/core package.json to support CommonJS module resolution
- Fixes ERR_PACKAGE_PATH_NOT_EXPORTED error when running `npm run dev`
- Enables tsx to properly resolve the @ees/core package using CommonJS resolution

## Problem
The development server was failing to start with the following error:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /Users/suzumiyaaoba/ghq/github.com/SuzumiyaAoba/ees/node_modules/@ees/core/package.json
```

This occurred because tsx was trying to resolve the package using CommonJS resolution, but the package only had ESM exports defined.

## Solution
Updated the exports configuration in `packages/core/package.json`:

**Before:**
```json
"exports": {
  ".": {
    "types": "./dist/index.d.ts",
    "import": "./dist/index.js"
  }
}
```

**After:**
```json
"exports": {
  ".": {
    "types": "./dist/index.d.ts",
    "import": "./dist/index.js",
    "require": "./dist/index.js"
  }
}
```

## Test plan
- [x] `npm run dev` now starts successfully without errors
- [x] Both ESM and CommonJS module resolution work for @ees/core package
- [x] Development server runs correctly with tsx watch
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)