### PR TITLE
docs: add mandatory import path standards using @/ alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,39 @@ The only exceptions are:
 
 ## Code Quality Standards
 
+### Import Path Standards
+
+**MANDATORY**: All imports must use the `@/` path alias format instead of relative paths (like `../` or `../../`).
+
+**Required Import Style:**
+```typescript
+// ✅ Correct - Use @/ path alias
+import { EmbeddingService } from "@/entities/embedding/api/embedding"
+import { DatabaseService } from "@/shared/database/database-service"
+import { ProviderModelError } from "@/shared/providers/types"
+
+// ❌ Incorrect - Relative paths not allowed
+import { EmbeddingService } from "../api/embedding"
+import { DatabaseService } from "../../../shared/database/database-service"
+import { ProviderModelError } from "../types"
+```
+
+**Path Mapping Configuration:**
+- The `@/` alias maps to `packages/core/src/` for the core package
+- This is configured in `tsconfig.json` with `"@/*": ["./*"]` under `paths`
+- All test files, implementation files, and modules must follow this convention
+
+**Benefits:**
+- **Consistency**: Uniform import style across the entire codebase
+- **Maintainability**: Easier to refactor and move files without breaking imports
+- **Readability**: Clear indication of module location without relative path complexity
+- **IDE Support**: Better autocomplete and navigation with absolute paths
+
+**Enforcement:**
+- All new code must use `@/` imports exclusively
+- When editing existing files, convert relative imports to `@/` format
+- Code reviews should reject PRs with relative import paths
+
 ### Biome Configuration Policy
 
 **IMPORTANT**: The `biome.json` configuration file is strictly protected and MUST NOT be edited by Claude Code.


### PR DESCRIPTION
## Summary
Add comprehensive documentation for import path standards requiring the use of `@/` path alias format instead of relative paths throughout the codebase.

## Changes
- **Add mandatory import path standards section** to AGENTS.md
- **Document required @/ import style** with clear examples showing correct vs incorrect usage
- **Explain path mapping configuration** and how it's configured in tsconfig.json
- **Define enforcement requirements** for code reviews and development workflow

## Import Path Standards
### Required Style:
```typescript
// ✅ Correct - Use @/ path alias
import { EmbeddingService } from "@/entities/embedding/api/embedding"
import { DatabaseService } from "@/shared/database/database-service"
import { ProviderModelError } from "@/shared/providers/types"

// ❌ Incorrect - Relative paths not allowed
import { EmbeddingService } from "../api/embedding"
import { DatabaseService } from "../../../shared/database/database-service"
import { ProviderModelError } from "../types"
```

## Benefits
- **Consistency**: Uniform import style across the entire codebase
- **Maintainability**: Easier to refactor and move files without breaking imports
- **Readability**: Clear indication of module location without relative path complexity
- **IDE Support**: Better autocomplete and navigation with absolute paths

## Enforcement Requirements
- All new code must use `@/` imports exclusively
- When editing existing files, convert relative imports to `@/` format
- Code reviews should reject PRs with relative import paths

## Test plan
- [x] Documentation follows existing AGENTS.md structure and formatting
- [x] Examples are clear and demonstrate both correct and incorrect usage
- [x] Configuration details are accurate and match actual tsconfig.json setup
- [x] Enforcement guidelines are practical and actionable

🤖 Generated with [Claude Code](https://claude.ai/code)