### PR TITLE
fix: resolve build configuration and model compatibility issues

### DIFF
--- a/packages/core/src/entities/embedding/__tests__/schemas.test.ts
+++ b/packages/core/src/entities/embedding/__tests__/schemas.test.ts
@@ -7,7 +7,7 @@ describe("Validation Schemas", () => {
       const validData = {
         uri: "file://test.txt",
         text: "Test document content",
-        model_name: "embeddinggemma:300m",
+        model_name: "nomic-embed-text",
       }
 
       const result = CreateEmbeddingSchema.safeParse(validData)
@@ -28,7 +28,7 @@ describe("Validation Schemas", () => {
 
       expect(result.success).toBe(true)
       if (result.success) {
-        expect(result.data.model_name).toBe("embeddinggemma:300m")
+        expect(result.data.model_name).toBe("nomic-embed-text")
       }
     })
 
@@ -40,7 +40,7 @@ describe("Validation Schemas", () => {
 
       const result = CreateEmbeddingSchema.parse(inputData)
 
-      expect(result.model_name).toBe("embeddinggemma:300m")
+      expect(result.model_name).toBe("nomic-embed-text")
     })
 
     it("should preserve custom model_name when provided", () => {
@@ -355,7 +355,7 @@ describe("Validation Schemas", () => {
     describe("Model name validation", () => {
       it("should accept standard model names", () => {
         const modelNames = [
-          "embeddinggemma:300m",
+          "nomic-embed-text",
           "llama2:7b",
           "mistral:latest",
           "custom-model:v1.0",
@@ -451,7 +451,7 @@ describe("Validation Schemas", () => {
         const modelName = result.model_name
 
         expect(typeof modelName).toBe("string")
-        expect(modelName).toBe("embeddinggemma:300m")
+        expect(modelName).toBe("nomic-embed-text")
       })
     })
 

--- a/packages/core/src/entities/embedding/model/openapi.ts
+++ b/packages/core/src/entities/embedding/model/openapi.ts
@@ -23,9 +23,9 @@ export const CreateEmbeddingRequestSchema = z
       description: "Text content to generate embedding for",
       example: "This is a sample text for embedding generation.",
     }),
-    model_name: z.string().optional().default("embeddinggemma:300m").openapi({
+    model_name: z.string().optional().default("nomic-embed-text").openapi({
       description: "Name of the embedding model to use",
-      example: "embeddinggemma:300m",
+      example: "nomic-embed-text",
     }),
   })
   .openapi("CreateEmbeddingRequest")
@@ -50,9 +50,9 @@ export const BatchCreateEmbeddingRequestSchema = z
       .openapi({
         description: "Array of texts to process (max 100 items)",
       }),
-    model_name: z.string().optional().default("embeddinggemma:300m").openapi({
+    model_name: z.string().optional().default("nomic-embed-text").openapi({
       description: "Name of the embedding model to use for all texts",
-      example: "embeddinggemma:300m",
+      example: "nomic-embed-text",
     }),
   })
   .openapi("BatchCreateEmbeddingRequest")
@@ -91,7 +91,7 @@ export const EmbeddingQuerySchema = z.object({
     .openapi({
       param: { name: "model_name", in: "query" },
       description: "Filter by model name (exact match)",
-      example: "embeddinggemma:300m",
+      example: "nomic-embed-text",
     }),
   page: z
     .string()
@@ -130,7 +130,7 @@ export const CreateEmbeddingResponseSchema = z
     }),
     model_name: z.string().openapi({
       description: "Model used for embedding generation",
-      example: "embeddinggemma:300m",
+      example: "nomic-embed-text",
     }),
     message: z.string().openapi({
       description: "Success message",
@@ -154,7 +154,7 @@ export const BatchCreateEmbeddingResponseSchema = z
           }),
           model_name: z.string().openapi({
             description: "Model used for embedding generation",
-            example: "embeddinggemma:300m",
+            example: "nomic-embed-text",
           }),
           status: z.enum(["success", "error"]).openapi({
             description: "Processing status",
@@ -190,9 +190,9 @@ export const SearchEmbeddingRequestSchema = z
       description: "Text query to search for similar embeddings",
       example: "machine learning algorithms",
     }),
-    model_name: z.string().optional().default("embeddinggemma:300m").openapi({
+    model_name: z.string().optional().default("nomic-embed-text").openapi({
       description: "Model name to use for query embedding generation",
-      example: "embeddinggemma:300m",
+      example: "nomic-embed-text",
     }),
     limit: z.number().int().min(1).max(100).optional().default(10).openapi({
       description: "Maximum number of results to return (max 100)",
@@ -229,7 +229,7 @@ export const SearchEmbeddingResultSchema = z
     }),
     model_name: z.string().openapi({
       description: "Model used for embedding",
-      example: "embeddinggemma:300m",
+      example: "nomic-embed-text",
     }),
     similarity: z.number().openapi({
       description: "Similarity score (higher = more similar)",
@@ -257,7 +257,7 @@ export const SearchEmbeddingResponseSchema = z
     }),
     model_name: z.string().openapi({
       description: "Model used for query embedding",
-      example: "embeddinggemma:300m",
+      example: "nomic-embed-text",
     }),
     metric: z.string().openapi({
       description: "Distance metric used for similarity calculation",
@@ -290,7 +290,7 @@ export const EmbeddingSchema = z
     }),
     model_name: z.string().openapi({
       description: "Model used for embedding",
-      example: "embeddinggemma:300m",
+      example: "nomic-embed-text",
     }),
     embedding: z.array(z.number()).openapi({
       description: "Embedding vector",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,10 +1,10 @@
 // Core EES package - shared types, utilities, and business logic
 
 // Re-export shared modules
-export * from './shared/index.js'
+export * from './shared/index'
 
 // Re-export entities (only non-conflicting exports)
-export { EmbeddingService } from './entities/embedding/index.js'
+export { EmbeddingService } from './entities/embedding/index'
 export type {
   CreateEmbeddingRequest,
   BatchCreateEmbeddingRequest,
@@ -14,7 +14,7 @@ export type {
   SearchEmbeddingResponse,
   EmbeddingsListResponse,
   Embedding
-} from './entities/embedding/model/embedding.js'
+} from './entities/embedding/model/embedding'
 
 // Export OpenAPI schemas for API package consumption
 export {
@@ -34,18 +34,18 @@ export {
   ErrorResponseSchema,
   NotFoundResponseSchema,
   ValidationErrorResponseSchema,
-} from './entities/embedding/model/openapi.js'
+} from './entities/embedding/model/openapi'
 
 // Explicitly export application layer and helpers for external packages
 export {
   EmbeddingApplicationService,
   EmbeddingApplicationServiceLive,
-} from './shared/application/embedding-application.js'
+} from './shared/application/embedding-application'
 
 export {
   CoreApplicationLayer,
   ApplicationLayer,
-} from './shared/application/layers.js'
+} from './shared/application/layers'
 
 export {
   getPort,
@@ -57,6 +57,6 @@ export {
   parseBatchFile,
   readStdin,
   readTextFile,
-} from './shared/lib/index.js'
+} from './shared/lib/index'
 
-export { DatabaseService } from './shared/database/connection.js'
+export { DatabaseService } from './shared/database/connection'

--- a/packages/core/src/shared/database/__tests__/migration.test.ts
+++ b/packages/core/src/shared/database/__tests__/migration.test.ts
@@ -323,7 +323,7 @@ describe("Database Migration Logic", () => {
                   id INTEGER PRIMARY KEY AUTOINCREMENT,
                   uri TEXT NOT NULL UNIQUE,
                   text TEXT NOT NULL,
-                  model_name TEXT NOT NULL DEFAULT 'embeddinggemma:300m',
+                  model_name TEXT NOT NULL DEFAULT 'nomic-embed-text',
                   embedding F32_BLOB(768) NOT NULL,
                   created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                   updated_at TEXT DEFAULT CURRENT_TIMESTAMP
@@ -450,7 +450,7 @@ describe("Database Migration Logic", () => {
                   id INTEGER PRIMARY KEY AUTOINCREMENT,
                   uri TEXT NOT NULL UNIQUE,
                   text TEXT NOT NULL,
-                  model_name TEXT NOT NULL DEFAULT 'embeddinggemma:300m',
+                  model_name TEXT NOT NULL DEFAULT 'nomic-embed-text',
                   embedding F32_BLOB(768) NOT NULL,
                   created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                   updated_at TEXT DEFAULT CURRENT_TIMESTAMP

--- a/packages/core/src/shared/database/connection.ts
+++ b/packages/core/src/shared/database/connection.ts
@@ -93,7 +93,7 @@ const make = Effect.gen(function* () {
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           uri TEXT NOT NULL UNIQUE,
           text TEXT NOT NULL,
-          model_name TEXT NOT NULL DEFAULT 'embeddinggemma:300m',
+          model_name TEXT NOT NULL DEFAULT 'nomic-embed-text',
           embedding F32_BLOB(768) NOT NULL,
           created_at TEXT DEFAULT CURRENT_TIMESTAMP,
           updated_at TEXT DEFAULT CURRENT_TIMESTAMP

--- a/packages/core/src/shared/database/schema.ts
+++ b/packages/core/src/shared/database/schema.ts
@@ -13,7 +13,7 @@ export const embeddings = sqliteTable(
     id: integer("id").primaryKey({ autoIncrement: true }),
     uri: text("uri").notNull().unique(),
     text: text("text").notNull(),
-    modelName: text("model_name").notNull().default("embeddinggemma:300m"),
+    modelName: text("model_name").notNull().default("nomic-embed-text"),
     embedding: blob("embedding").notNull(),
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`),
     updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`),

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,8 +8,9 @@
     "composite": true,
     "noEmit": false,
     "allowImportingTsExtensions": false,
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "ES2022",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -19,6 +20,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": false,
     "baseUrl": "./src",
     "paths": {
       "@/*": ["./*"]


### PR DESCRIPTION
## Summary
- Fixes TypeScript build configuration issues in the core package that were preventing proper module resolution
- Replaces hardcoded `embeddinggemma:300m` model references with `nomic-embed-text` to ensure compatibility with available Ollama models
- Resolves API server startup failures due to module resolution errors

## Changes Made

### Build Configuration Fixes
- **TypeScript Module System**: Changed from `ESNext/bundler` to `CommonJS/node` for proper declaration file generation
- **Module Syntax**: Disabled `verbatimModuleSyntax` to resolve import/export conflicts with CommonJS output
- **Import Paths**: Removed `.js` extensions from import paths for CommonJS compatibility
- **Declaration Files**: Now properly generates `index.d.ts` and all necessary TypeScript declaration files

### Model Compatibility
- **Database Schema**: Updated default model value from `embeddinggemma:300m` to `nomic-embed-text`
- **Database Migration**: Fixed table creation SQL to use correct default model
- **OpenAPI Schemas**: Updated all examples and default values to use `nomic-embed-text`
- **Search Endpoint**: Now works correctly without model not found errors

### Module Resolution
- **Core Package**: Fixed "Cannot find module '@ees/core'" errors across API and CLI packages
- **Type Checking**: Enabled proper TypeScript type checking across all packages
- **API Server**: Now starts successfully without module resolution failures

## Test Results
- ✅ API server starts successfully on `http://localhost:3000`
- ✅ `/embeddings/search` endpoint works with default model
- ✅ `/embeddings` create endpoint works with default model
- ✅ Core package builds and generates proper declaration files
- ✅ Module resolution errors resolved across packages

## Related Issues
- Fixes build configuration problems reported in previous issues
- Resolves `/embeddings/search` endpoint errors
- Addresses module resolution failures preventing API server startup

🤖 Generated with [Claude Code](https://claude.ai/code)