### PR TITLE
refactor: consolidate duplicate test helper patterns across provider tests (Issue #73)

### DIFF
--- a/packages/core/src/shared/providers/__tests__/test-helpers.test.ts
+++ b/packages/core/src/shared/providers/__tests__/test-helpers.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Tests for shared test helper utilities
+ * Ensures test helpers work correctly before using them in provider tests
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { Effect, Either } from "effect"
+import {
+  createMockEmbeddingResponse,
+  setupMockFetch,
+  expectEmbeddingResult,
+  expectProviderError,
+  expectFetchCall,
+  createTestRequest,
+  setupErrorScenarios,
+  createTestEnvironment,
+  expectModelListStructure,
+  TEST_EMBEDDINGS,
+  TEST_MODELS,
+  type MockFetchConfig,
+} from "./test-helpers"
+import type { EmbeddingResponse } from "../types"
+import { ProviderModelError } from "../types"
+
+describe("Test Helpers", () => {
+  let testEnv: ReturnType<typeof createTestEnvironment>
+
+  beforeEach(() => {
+    testEnv = createTestEnvironment()
+  })
+
+  afterEach(() => {
+    testEnv.cleanup()
+  })
+
+  describe("createMockEmbeddingResponse", () => {
+    it("should create response with single embedding", () => {
+      const embedding = [0.1, 0.2, 0.3]
+      const model = "test-model"
+
+      const response = createMockEmbeddingResponse(embedding, model)
+
+      expect(response).toEqual({
+        embeddings: [embedding],
+        embedding,
+        model,
+        provider: undefined,
+        total_duration: undefined,
+        load_duration: undefined,
+        usage: undefined,
+      })
+    })
+
+    it("should create response with multiple embeddings", () => {
+      const embeddings = [[0.1, 0.2], [0.3, 0.4]]
+      const model = "test-model"
+
+      const response = createMockEmbeddingResponse(embeddings, model)
+
+      expect(response).toEqual({
+        embeddings,
+        embedding: embeddings[0],
+        model,
+        provider: undefined,
+        total_duration: undefined,
+        load_duration: undefined,
+        usage: undefined,
+      })
+    })
+
+    it("should create response with optional parameters", () => {
+      const embedding = [0.1, 0.2, 0.3]
+      const model = "test-model"
+      const options = {
+        provider: "test-provider",
+        usage: { tokens: 10 },
+        total_duration: 1000,
+        load_duration: 500,
+      }
+
+      const response = createMockEmbeddingResponse(embedding, model, options)
+
+      expect(response).toEqual({
+        embeddings: [embedding],
+        embedding,
+        model,
+        provider: "test-provider",
+        total_duration: 1000,
+        load_duration: 500,
+        usage: { tokens: 10 },
+      })
+    })
+  })
+
+  describe("setupMockFetch", () => {
+    it("should setup successful mock fetch", async () => {
+      const data = { test: "data" }
+      const config: MockFetchConfig = {
+        ok: true,
+        status: 200,
+        data,
+      }
+
+      setupMockFetch(config)
+
+      // Actually call fetch to verify the mock works
+      const response = await fetch("http://test.com")
+      expect(response.ok).toBe(true)
+      expect(response.status).toBe(200)
+
+      const jsonData = await response.json()
+      expect(jsonData).toEqual(data)
+    })
+
+    it("should setup error mock fetch", async () => {
+      const config: MockFetchConfig = {
+        ok: false,
+        status: 404,
+        error: "Not found",
+      }
+
+      setupMockFetch(config)
+
+      // Actually call fetch to verify the mock works
+      const response = await fetch("http://test.com")
+      expect(response.ok).toBe(false)
+      expect(response.status).toBe(404)
+
+      const errorText = await response.text()
+      expect(errorText).toBe("Not found")
+    })
+
+    it("should setup mock fetch with custom headers", async () => {
+      const config: MockFetchConfig = {
+        ok: true,
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }
+
+      setupMockFetch(config)
+
+      // Actually call fetch to verify the mock works
+      const response = await fetch("http://test.com")
+      expect(response.ok).toBe(true)
+      expect(response.status).toBe(200)
+      expect(response.headers.get("Content-Type")).toBe("application/json")
+    })
+  })
+
+  describe("expectEmbeddingResult", () => {
+    it("should validate all embedding result properties", () => {
+      const result: EmbeddingResponse = {
+        embedding: [0.1, 0.2, 0.3],
+        model: "test-model",
+        provider: "test-provider",
+        dimensions: 3,
+        tokensUsed: 10,
+      }
+
+      const expected: Partial<EmbeddingResponse> = {
+        embedding: [0.1, 0.2, 0.3],
+        model: "test-model",
+        provider: "test-provider",
+        dimensions: 3,
+        tokensUsed: 10,
+      }
+
+      // Should not throw
+      expectEmbeddingResult(result, expected)
+    })
+
+    it("should validate partial embedding result properties", () => {
+      const result: EmbeddingResponse = {
+        embedding: [0.1, 0.2, 0.3],
+        model: "test-model",
+        provider: "test-provider",
+        dimensions: 3,
+        tokensUsed: 10,
+      }
+
+      const expected: Partial<EmbeddingResponse> = {
+        model: "test-model",
+        dimensions: 3,
+      }
+
+      // Should not throw when checking only specified properties
+      expectEmbeddingResult(result, expected)
+    })
+
+    it("should fail when embedding result doesn't match", () => {
+      const result: EmbeddingResponse = {
+        embedding: [0.1, 0.2, 0.3],
+        model: "test-model",
+        provider: "test-provider",
+        dimensions: 3,
+        tokensUsed: 10,
+      }
+
+      const expected: Partial<EmbeddingResponse> = {
+        model: "wrong-model",
+      }
+
+      expect(() => expectEmbeddingResult(result, expected)).toThrow()
+    })
+  })
+
+  describe("expectProviderError", () => {
+    it("should validate error type correctly", async () => {
+      const errorEffect = Effect.fail(
+        new ProviderModelError({
+          provider: "test",
+          modelName: "test-model",
+          message: "Test error",
+        })
+      )
+
+      const error = await expectProviderError(ProviderModelError, errorEffect)
+
+      expect(error).toBeInstanceOf(ProviderModelError)
+      expect(error.provider).toBe("test")
+      expect(error.modelName).toBe("test-model")
+      expect(error.message).toBe("Test error")
+    })
+
+    it("should fail when operation succeeds unexpectedly", async () => {
+      const successEffect = Effect.succeed("success")
+
+      await expect(async () => {
+        await expectProviderError(ProviderModelError, successEffect)
+      }).rejects.toThrow("Expected operation to fail but it succeeded")
+    })
+
+    it("should fail when error type doesn't match", async () => {
+      const errorEffect = Effect.fail(new Error("Generic error"))
+
+      await expect(
+        expectProviderError(ProviderModelError, errorEffect)
+      ).rejects.toThrow()
+    })
+  })
+
+  describe("expectFetchCall", () => {
+    it("should validate fetch call parameters", () => {
+      const url = "https://api.example.com/embed"
+      const options = {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "test" }),
+      }
+
+      // Setup mock call
+      testEnv.mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({}),
+      } as any)
+
+      // Make the call
+      fetch(url, options)
+
+      // Validate it was called correctly
+      expectFetchCall(url, options)
+    })
+  })
+
+  describe("createTestRequest", () => {
+    it("should create request with text only", () => {
+      const request = createTestRequest("test text")
+
+      expect(request).toEqual({
+        text: "test text",
+      })
+    })
+
+    it("should create request with text and model", () => {
+      const request = createTestRequest("test text", "test-model")
+
+      expect(request).toEqual({
+        text: "test text",
+        modelName: "test-model",
+      })
+    })
+  })
+
+  describe("TEST_EMBEDDINGS constants", () => {
+    it("should have correct embedding dimensions", () => {
+      expect(TEST_EMBEDDINGS.SMALL).toHaveLength(5)
+      expect(TEST_EMBEDDINGS.MEDIUM).toHaveLength(384)
+      expect(TEST_EMBEDDINGS.LARGE).toHaveLength(1024)
+      expect(TEST_EMBEDDINGS.OPENAI_SMALL).toHaveLength(1536)
+      expect(TEST_EMBEDDINGS.OPENAI_LARGE).toHaveLength(3072)
+      expect(TEST_EMBEDDINGS.COHERE).toHaveLength(1024)
+      expect(TEST_EMBEDDINGS.GOOGLE).toHaveLength(768)
+      expect(TEST_EMBEDDINGS.OLLAMA).toHaveLength(5)
+    })
+
+    it("should have numeric values", () => {
+      Object.values(TEST_EMBEDDINGS).forEach((embedding) => {
+        expect(Array.isArray(embedding)).toBe(true)
+        embedding.forEach((value) => {
+          expect(typeof value).toBe("number")
+        })
+      })
+    })
+  })
+
+  describe("TEST_MODELS constants", () => {
+    it("should have expected model names", () => {
+      expect(TEST_MODELS.OPENAI.SMALL).toBe("text-embedding-3-small")
+      expect(TEST_MODELS.OPENAI.LARGE).toBe("text-embedding-3-large")
+      expect(TEST_MODELS.GOOGLE.EMBEDDING_001).toBe("embedding-001")
+      expect(TEST_MODELS.COHERE.ENGLISH).toBe("embed-english-v3.0")
+      expect(TEST_MODELS.OLLAMA.NOMIC).toBe("nomic-embed-text")
+      expect(TEST_MODELS.MISTRAL.EMBED).toBe("mistral-embed")
+    })
+  })
+
+  describe("setupErrorScenarios", () => {
+    it("should setup different error scenarios", () => {
+      const scenarios = setupErrorScenarios()
+
+      expect(typeof scenarios.networkError).toBe("function")
+      expect(typeof scenarios.unauthorized).toBe("function")
+      expect(typeof scenarios.rateLimited).toBe("function")
+      expect(typeof scenarios.modelNotFound).toBe("function")
+      expect(typeof scenarios.invalidRequest).toBe("function")
+      expect(typeof scenarios.serverError).toBe("function")
+    })
+
+    it("should create network error scenario", async () => {
+      const scenarios = setupErrorScenarios()
+
+      // Setup the scenario
+      scenarios.networkError()
+
+      // Test that fetch was configured with network error
+      const response = await fetch("http://test.com")
+      expect(response.ok).toBe(false)
+      expect(response.status).toBe(0)
+    })
+  })
+
+  describe("expectModelListStructure", () => {
+    it("should validate correct model list structure", () => {
+      const models = [
+        {
+          name: "test-model-1",
+          provider: "test-provider",
+          dimensions: 768,
+          maxTokens: 8192,
+        },
+        {
+          name: "test-model-2",
+          provider: "test-provider",
+          dimensions: 1024,
+          maxTokens: 4096,
+        },
+      ]
+
+      // Should not throw
+      expectModelListStructure(models, "test-provider")
+    })
+
+    it("should fail for empty model list", () => {
+      const models: any[] = []
+
+      expect(() => expectModelListStructure(models, "test-provider")).toThrow()
+    })
+
+    it("should fail for invalid model structure", () => {
+      const models = [
+        {
+          name: "test-model",
+          // Missing provider
+          dimensions: 768,
+        },
+      ]
+
+      expect(() => expectModelListStructure(models, "test-provider")).toThrow()
+    })
+
+    it("should fail for wrong provider", () => {
+      const models = [
+        {
+          name: "test-model",
+          provider: "wrong-provider",
+          dimensions: 768,
+        },
+      ]
+
+      expect(() => expectModelListStructure(models, "test-provider")).toThrow()
+    })
+  })
+
+  describe("createTestEnvironment", () => {
+    it("should create test environment with cleanup", () => {
+      const env = createTestEnvironment()
+
+      expect(env.mockFetch).toBeDefined()
+      expect(typeof env.cleanup).toBe("function")
+      expect(global.fetch).toBe(env.mockFetch)
+
+      // Cleanup should restore mocks
+      env.cleanup()
+    })
+  })
+})

--- a/packages/core/src/shared/providers/__tests__/test-helpers.ts
+++ b/packages/core/src/shared/providers/__tests__/test-helpers.ts
@@ -1,0 +1,323 @@
+/**
+ * Shared test helper utilities for provider tests
+ * Eliminates code duplication and standardizes test patterns across all providers
+ */
+
+import { Effect, Either } from "effect"
+import { vi } from "vitest"
+import type { EmbeddingProvider, EmbeddingRequest, EmbeddingResponse } from "../types"
+
+/**
+ * Mock embedding response structure
+ */
+export interface MockEmbeddingResponse {
+  readonly embeddings?: number[][]
+  readonly embedding?: number[]
+  readonly model: string
+  readonly provider?: string
+  readonly total_duration?: number
+  readonly load_duration?: number
+  readonly prompt_eval_count?: number
+  readonly usage?: {
+    readonly tokens: number
+  }
+}
+
+/**
+ * Mock fetch response configuration
+ */
+export interface MockFetchConfig {
+  readonly ok: boolean
+  readonly status: number
+  readonly data?: MockEmbeddingResponse | any
+  readonly error?: string
+  readonly headers?: Record<string, string>
+}
+
+/**
+ * Create a mock embedding response for testing
+ */
+export function createMockEmbeddingResponse(
+  embeddings: number[][] | number[],
+  model: string,
+  options?: {
+    provider?: string
+    usage?: { tokens: number }
+    total_duration?: number
+    load_duration?: number
+  }
+): MockEmbeddingResponse {
+  const embeddingArray = Array.isArray(embeddings[0]) ? embeddings as number[][] : [embeddings as number[]]
+
+  return {
+    embeddings: embeddingArray,
+    embedding: embeddingArray[0], // For providers that return single embedding
+    model,
+    provider: options?.provider,
+    total_duration: options?.total_duration,
+    load_duration: options?.load_duration,
+    usage: options?.usage,
+  }
+}
+
+/**
+ * Setup mock fetch with standardized response format
+ */
+export function setupMockFetch(config: MockFetchConfig): void {
+  const mockFetch = vi.mocked(global.fetch)
+
+  mockFetch.mockResolvedValue({
+    ok: config.ok,
+    status: config.status,
+    headers: new Headers(config.headers || {}),
+    json: vi.fn().mockResolvedValue(config.data || {}),
+    text: vi.fn().mockResolvedValue(config.error || ""),
+    blob: vi.fn().mockResolvedValue(new Blob()),
+    arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+    clone: vi.fn().mockReturnThis(),
+  } as any)
+}
+
+/**
+ * Setup mock fetch to reject with an error (for network errors)
+ */
+export function setupMockFetchError(error: Error): void {
+  const mockFetch = vi.mocked(global.fetch)
+  mockFetch.mockRejectedValue(error)
+}
+
+/**
+ * Setup mock fetch with JSON parse error
+ */
+export function setupMockFetchJsonError(jsonError: Error): void {
+  const mockFetch = vi.mocked(global.fetch)
+
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    json: vi.fn().mockRejectedValue(jsonError),
+    text: vi.fn().mockResolvedValue(""),
+    blob: vi.fn().mockResolvedValue(new Blob()),
+    arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+    clone: vi.fn().mockReturnThis(),
+  } as any)
+}
+
+/**
+ * Execute a provider test with standardized error handling
+ */
+export async function runProviderTest<T extends EmbeddingProvider>(
+  provider: T,
+  request: EmbeddingRequest
+): Promise<EmbeddingResponse> {
+  return await Effect.runPromise(provider.generateEmbedding(request))
+}
+
+/**
+ * Execute a provider test and capture the result with Either
+ */
+export async function runProviderTestWithEither<T extends EmbeddingProvider>(
+  provider: T,
+  request: EmbeddingRequest
+): Promise<Either.Either<EmbeddingResponse, any>> {
+  return await Effect.runPromise(Effect.either(provider.generateEmbedding(request)))
+}
+
+/**
+ * Standardized assertions for embedding results
+ */
+export function expectEmbeddingResult(
+  result: EmbeddingResponse,
+  expected: Partial<EmbeddingResponse>
+): void {
+  if (expected.embedding !== undefined) {
+    expect(result.embedding).toEqual(expected.embedding)
+  }
+  if (expected.model !== undefined) {
+    expect(result.model).toBe(expected.model)
+  }
+  if (expected.provider !== undefined) {
+    expect(result.provider).toBe(expected.provider)
+  }
+  if (expected.dimensions !== undefined) {
+    expect(result.dimensions).toBe(expected.dimensions)
+  }
+  if (expected.tokensUsed !== undefined) {
+    expect(result.tokensUsed).toBe(expected.tokensUsed)
+  }
+}
+
+/**
+ * Test that a provider operation fails with the expected error type
+ */
+export async function expectProviderError<T>(
+  errorType: new (...args: any[]) => T,
+  operation: Effect.Effect<any, any, any>
+): Promise<T> {
+  const result = await Effect.runPromise(Effect.either(operation))
+
+  if (Either.isRight(result)) {
+    throw new Error("Expected operation to fail but it succeeded")
+  }
+
+  const error = result.left
+  expect(error).toBeInstanceOf(errorType)
+  return error as T
+}
+
+/**
+ * Assert that fetch was called with expected parameters
+ */
+export function expectFetchCall(
+  url: string,
+  options: {
+    method: string
+    headers: Record<string, string>
+    body: string
+  }
+): void {
+  const mockFetch = vi.mocked(global.fetch)
+
+  expect(mockFetch).toHaveBeenCalledWith(url, {
+    method: options.method,
+    headers: options.headers,
+    body: options.body,
+  })
+}
+
+/**
+ * Create standardized test request
+ */
+export function createTestRequest(
+  text: string,
+  modelName?: string
+): EmbeddingRequest {
+  return {
+    text,
+    ...(modelName && { modelName }),
+  }
+}
+
+/**
+ * Common test data for embedding vectors
+ */
+export const TEST_EMBEDDINGS = {
+  SMALL: [0.1, 0.2, 0.3, 0.4, 0.5],
+  MEDIUM: new Array(384).fill(0).map((_, i) => i / 384),
+  LARGE: new Array(1024).fill(0).map((_, i) => i / 1024),
+  OPENAI_SMALL: new Array(1536).fill(0.1),
+  OPENAI_LARGE: new Array(3072).fill(0.1),
+  COHERE: new Array(1024).fill(0.1),
+  GOOGLE: new Array(768).fill(0.1),
+  OLLAMA: [0.1, 0.2, 0.3, 0.4, 0.5],
+} as const
+
+/**
+ * Common test models for different providers
+ */
+export const TEST_MODELS = {
+  OPENAI: {
+    SMALL: "text-embedding-3-small",
+    LARGE: "text-embedding-3-large",
+    ADA: "text-embedding-ada-002",
+  },
+  GOOGLE: {
+    EMBEDDING_001: "embedding-001",
+    TEXT_EMBEDDING_004: "text-embedding-004",
+  },
+  COHERE: {
+    ENGLISH: "embed-english-v3.0",
+    MULTILINGUAL: "embed-multilingual-v3.0",
+  },
+  OLLAMA: {
+    NOMIC: "nomic-embed-text",
+    MXBAI: "mxbai-embed-large",
+    ARCTIC: "snowflake-arctic-embed",
+  },
+  MISTRAL: {
+    EMBED: "mistral-embed",
+  },
+  AZURE: {
+    ADA: "text-embedding-ada-002",
+    SMALL: "text-embedding-3-small",
+  },
+} as const
+
+/**
+ * Setup common error scenarios for testing
+ */
+export function setupErrorScenarios() {
+  return {
+    networkError: () => setupMockFetch({
+      ok: false,
+      status: 0,
+      error: "Network error",
+    }),
+
+    unauthorized: () => setupMockFetch({
+      ok: false,
+      status: 401,
+      error: "Unauthorized",
+    }),
+
+    rateLimited: () => setupMockFetch({
+      ok: false,
+      status: 429,
+      error: "Rate limit exceeded",
+    }),
+
+    modelNotFound: () => setupMockFetch({
+      ok: false,
+      status: 404,
+      error: "Model not found",
+    }),
+
+    invalidRequest: () => setupMockFetch({
+      ok: false,
+      status: 400,
+      error: "Bad request",
+    }),
+
+    serverError: () => setupMockFetch({
+      ok: false,
+      status: 500,
+      error: "Internal server error",
+    }),
+  }
+}
+
+/**
+ * Create a standardized test environment setup
+ */
+export function createTestEnvironment() {
+  const mockFetch = vi.fn()
+  global.fetch = mockFetch
+
+  return {
+    mockFetch,
+    cleanup: () => {
+      vi.restoreAllMocks()
+    },
+  }
+}
+
+/**
+ * Helper to assert model list response structure
+ */
+export function expectModelListStructure(
+  models: any[],
+  expectedProvider: string
+): void {
+  expect(Array.isArray(models)).toBe(true)
+  expect(models.length).toBeGreaterThan(0)
+
+  for (const model of models) {
+    expect(model).toHaveProperty("name")
+    expect(model).toHaveProperty("provider")
+    expect(model).toHaveProperty("dimensions")
+    expect(model.provider).toBe(expectedProvider)
+    expect(typeof model.name).toBe("string")
+    expect(typeof model.dimensions).toBe("number")
+  }
+}


### PR DESCRIPTION
## Summary
Addresses Issue #73 by eliminating massive code duplication in provider test patterns through comprehensive shared test utilities.

## Key Changes

### 🆕 New Files
- **`test-helpers.ts`**: Comprehensive shared test utilities
  - Mock response builders (`createMockEmbeddingResponse`)
  - Fetch mocking utilities (`setupMockFetch`, `setupMockFetchError`, `setupMockFetchJsonError`)
  - Standardized assertions (`expectEmbeddingResult`, `expectProviderError`) 
  - Test environment management (`createTestEnvironment`)
  - Centralized test data (`TEST_EMBEDDINGS`, `TEST_MODELS`)

- **`test-helpers.test.ts`**: 25 comprehensive tests for all helper functions
  - Full coverage of helper functionality
  - Error scenarios and edge cases validation
  - All tests passing ✅

### 🔄 Refactored Files
- **`ollama-provider.test.ts`**: Complete refactoring of 22 test cases
  - Eliminated repetitive mock setup patterns
  - Standardized error handling with Effect patterns
  - Centralized test data usage
  - Improved readability and maintainability

## Technical Improvements

- **Type Safety**: Leveraged TypeScript generics and Effect-ts patterns
- **Code Reusability**: Eliminated repetitive mock setup across provider tests
- **Maintainability**: Centralized test patterns make future changes easier
- **Consistency**: Standardized test structure across all provider tests

## Test plan

✅ All 115 provider tests passing across 7 test files
✅ TypeScript type checking passes  
✅ Linting passes with no errors
✅ Comprehensive test coverage for shared helpers (25 test cases)

## Benefits

- ✨ Eliminates massive duplication in provider test patterns
- 🔧 Improves code maintainability through shared utilities
- 🛡️ Enhances test reliability with standardized patterns
- ⚡ Reduces future development overhead for new provider tests

This refactoring establishes a solid foundation for consistent, maintainable provider testing across the entire codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)