### PR TITLE
refactor: standardize import paths to use @/ alias (Issue #105)

### DIFF
--- a/packages/core/src/entities/embedding/__tests__/embedding-data.test.ts
+++ b/packages/core/src/entities/embedding/__tests__/embedding-data.test.ts
@@ -4,7 +4,7 @@ import {
   EmbeddingDataParseError,
   parseStoredEmbeddingData,
   validateEmbeddingVector,
-} from "../lib/embedding-data"
+} from "@/entities/embedding/lib/embedding-data"
 
 describe("EmbeddingDataParser", () => {
   describe("parseStoredEmbeddingData", () => {

--- a/packages/core/src/entities/embedding/__tests__/embedding.test.ts
+++ b/packages/core/src/entities/embedding/__tests__/embedding.test.ts
@@ -17,7 +17,7 @@ import { EmbeddingService, EmbeddingServiceLive } from "@/entities/embedding/api
 import type {
   BatchCreateEmbeddingRequest,
   SearchEmbeddingRequest,
-} from "../model/embedding"
+} from "@/entities/embedding/model/embedding"
 
 // Mock implementations
 interface MockEmbeddingProviderService {

--- a/packages/core/src/entities/embedding/api/embedding.ts
+++ b/packages/core/src/entities/embedding/api/embedding.ts
@@ -31,7 +31,7 @@ import type {
   EmbeddingsListResponse,
   SearchEmbeddingRequest,
   SearchEmbeddingResponse,
-} from "../model/embedding"
+} from "@/entities/embedding/model/embedding"
 
 /**
  * Multi-provider embedding service interface

--- a/packages/core/src/entities/embedding/lib/embedding-data.ts
+++ b/packages/core/src/entities/embedding/lib/embedding-data.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect"
 import {
   EmbeddingVectorSchema,
   StoredEmbeddingDataSchema,
-} from "../model/openapi"
+} from "@/entities/embedding/model/openapi"
 
 export class EmbeddingDataParseError extends Error {
   constructor(message: string, cause?: unknown) {

--- a/packages/core/src/shared/application/__tests__/embedding-application.test.ts
+++ b/packages/core/src/shared/application/__tests__/embedding-application.test.ts
@@ -13,12 +13,12 @@ import type {
   EmbeddingsListResponse,
   SearchEmbeddingRequest,
   SearchEmbeddingResponse,
-} from "../../../entities/embedding/model/embedding"
+} from "@/entities/embedding/model/embedding"
 import { DatabaseService } from "@/shared/database/connection"
 import {
   EmbeddingApplicationService,
   EmbeddingApplicationServiceLive,
-} from "../embedding-application"
+} from "@/shared/application/embedding-application"
 
 describe("EmbeddingApplicationService", () => {
   let mockEmbeddingService: {

--- a/packages/core/src/shared/application/__tests__/layers.test.ts
+++ b/packages/core/src/shared/application/__tests__/layers.test.ts
@@ -9,7 +9,7 @@ import { DatabaseService } from "@/shared/database/connection"
 import {
   EmbeddingApplicationService,
   EmbeddingApplicationServiceLive,
-} from "../embedding-application"
+} from "@/shared/application/embedding-application"
 import { ApplicationLayer, CoreApplicationLayer } from "@/shared/application/layers"
 
 describe("Application Layers", () => {

--- a/packages/core/src/shared/application/embedding-application.ts
+++ b/packages/core/src/shared/application/embedding-application.ts
@@ -15,14 +15,14 @@ import type {
   EmbeddingsListResponse,
   SearchEmbeddingRequest,
   SearchEmbeddingResponse,
-} from "../../entities/embedding/model/embedding"
+} from "@/entities/embedding/model/embedding"
 import type { DatabaseQueryError } from "@/shared/errors/database"
 import type {
   ProviderAuthenticationError,
   ProviderConnectionError,
   ProviderModelError,
   ProviderRateLimitError,
-} from "../providers/types"
+} from "@/shared/providers/types"
 
 /**
  * Application-level embedding operations interface

--- a/packages/core/src/shared/config/__tests__/provider-factory.test.ts
+++ b/packages/core/src/shared/config/__tests__/provider-factory.test.ts
@@ -6,7 +6,7 @@ import type {
   GoogleConfig,
   AzureConfig,
   OllamaConfig,
-} from "../../providers/types"
+} from "@/shared/providers/types"
 
 // Mock the env module
 vi.mock("../../lib/env", () => ({

--- a/packages/core/src/shared/config/__tests__/provider-templates.test.ts
+++ b/packages/core/src/shared/config/__tests__/provider-templates.test.ts
@@ -7,7 +7,7 @@ import {
   OLLAMA_CONFIG_TEMPLATE,
   OPENAI_CONFIG_TEMPLATE,
   ALL_PROVIDER_TEMPLATES,
-} from "../provider-templates"
+} from "@/shared/config/provider-templates"
 import { createProviderConfig, createSimpleProviderConfig } from "@/shared/config/provider-factory"
 import { ENV_KEYS } from "@/shared/config/env-keys"
 

--- a/packages/core/src/shared/config/__tests__/providers.test.ts
+++ b/packages/core/src/shared/config/__tests__/providers.test.ts
@@ -11,7 +11,7 @@ import {
   getOpenAIConfig,
   getProviderConfigSummary,
   validateProviderConfig,
-} from "../providers"
+} from "@/shared/config/providers"
 import { ENV_KEYS } from "@/shared/config/env-keys"
 
 describe("Provider Configuration", () => {

--- a/packages/core/src/shared/config/provider-templates.ts
+++ b/packages/core/src/shared/config/provider-templates.ts
@@ -9,9 +9,9 @@ import type {
   GoogleConfig,
   MistralConfig,
   OpenAIConfig,
-} from "../providers/types"
-import type { ProviderConfigTemplate } from "./provider-factory"
-import { ENV_KEYS } from "./env-keys"
+} from "@/shared/providers/types"
+import type { ProviderConfigTemplate } from "@/shared/config/provider-factory"
+import { ENV_KEYS } from "@/shared/config/env-keys"
 
 /**
  * Ollama configuration template

--- a/packages/core/src/shared/config/providers.ts
+++ b/packages/core/src/shared/config/providers.ts
@@ -13,8 +13,8 @@ import type {
   OllamaConfig,
   OpenAIConfig,
   ProviderConfig,
-} from "../providers/types"
-import { createProviderConfig, createSimpleProviderConfig } from "./provider-factory"
+} from "@/shared/providers/types"
+import { createProviderConfig, createSimpleProviderConfig } from "@/shared/config/provider-factory"
 import {
   AZURE_CONFIG_TEMPLATE,
   COHERE_CONFIG_TEMPLATE,
@@ -22,8 +22,8 @@ import {
   MISTRAL_CONFIG_TEMPLATE,
   OLLAMA_CONFIG_TEMPLATE,
   OPENAI_CONFIG_TEMPLATE,
-} from "./provider-templates"
-import { ENV_KEYS } from "./env-keys"
+} from "@/shared/config/provider-templates"
+import { ENV_KEYS } from "@/shared/config/env-keys"
 
 /**
  * Get Ollama configuration from environment

--- a/packages/core/src/shared/lib/__tests__/file-processor.test.ts
+++ b/packages/core/src/shared/lib/__tests__/file-processor.test.ts
@@ -21,7 +21,7 @@ import {
   type FileProcessorConfig,
   processFile,
   processFiles,
-} from "../file-processor"
+} from "@/shared/lib/file-processor"
 
 describe("File Processor", () => {
   let testDir: string

--- a/packages/core/src/shared/lib/test-helpers.ts
+++ b/packages/core/src/shared/lib/test-helpers.ts
@@ -5,7 +5,7 @@ import {
   EmbeddingSchema,
   EmbeddingsListResponseSchema,
   SearchEmbeddingResponseSchema,
-} from "../../entities/embedding/model/openapi"
+} from "@/entities/embedding/model/openapi"
 
 export class TestResponseParseError extends Error {
   constructor(message: string, cause?: unknown) {

--- a/packages/core/src/shared/models/__tests__/model-manager.test.ts
+++ b/packages/core/src/shared/models/__tests__/model-manager.test.ts
@@ -22,7 +22,7 @@ import {
   ModelNotFoundError,
   ModelIncompatibleError,
   MigrationError,
-} from "../"
+} from "@/shared/models"
 
 describe("ModelManager", () => {
   let mockProviderService: typeof EmbeddingProviderService.Service

--- a/packages/core/src/shared/models/types.ts
+++ b/packages/core/src/shared/models/types.ts
@@ -9,7 +9,7 @@ import type {
   ProviderConnectionError,
   ProviderModelError,
   ProviderRateLimitError
-} from "../providers/types"
+} from "@/shared/providers/types"
 import type { DatabaseQueryError } from "@/shared/errors/database"
 
 /**

--- a/packages/core/src/shared/providers/__tests__/factory.test.ts
+++ b/packages/core/src/shared/providers/__tests__/factory.test.ts
@@ -9,7 +9,7 @@ import {
   createOllamaConfig,
   createOpenAIConfig,
   createProviderLayer,
-} from "../factory"
+} from "@/shared/providers/factory"
 
 describe("Provider Factory", () => {
   describe("createOllamaConfig", () => {

--- a/packages/core/src/shared/providers/__tests__/integration.test.ts
+++ b/packages/core/src/shared/providers/__tests__/integration.test.ts
@@ -10,7 +10,7 @@ import {
   createMultiProviderConfig,
   createOllamaConfig,
   EmbeddingProviderService,
-} from "../factory"
+} from "@/shared/providers/factory"
 import { createOllamaProvider } from "@/shared/providers/ollama-provider"
 
 describe("Provider System Integration", () => {

--- a/packages/core/src/shared/providers/__tests__/types.test.ts
+++ b/packages/core/src/shared/providers/__tests__/types.test.ts
@@ -8,7 +8,7 @@ import {
   ProviderConnectionError,
   ProviderModelError,
   ProviderRateLimitError,
-} from "../types"
+} from "@/shared/providers/types"
 
 describe("Provider Error Types", () => {
   describe("ProviderConnectionError", () => {

--- a/packages/core/src/shared/providers/index.ts
+++ b/packages/core/src/shared/providers/index.ts
@@ -12,8 +12,8 @@ export {
   getOpenAIConfig,
   getProviderConfigSummary,
   validateProviderConfig,
-} from "../config/providers"
-export { ENV_KEYS } from "../config/env-keys"
+} from "@/shared/config/providers"
+export { ENV_KEYS } from "@/shared/config/env-keys"
 // Provider implementations
 export {
   AzureProviderService,


### PR DESCRIPTION
## Summary
Standardize all import paths to use `@/` path alias format instead of relative paths (`../`) across the codebase, improving maintainability and consistency.

## Changes
- ✅ Converted 20 files from relative imports to `@/` path alias
  - 8 production files
  - 12 test files
- ✅ Maintains compatibility with existing TypeScript configuration
- ✅ Follows CLAUDE.md coding standards

## Files Modified
### Production Code (8 files)
- `packages/core/src/entities/embedding/api/embedding.ts`
- `packages/core/src/entities/embedding/lib/embedding-data.ts`
- `packages/core/src/shared/application/embedding-application.ts`
- `packages/core/src/shared/config/provider-templates.ts`
- `packages/core/src/shared/config/providers.ts`
- `packages/core/src/shared/lib/test-helpers.ts`
- `packages/core/src/shared/models/types.ts`
- `packages/core/src/shared/providers/index.ts`

### Test Files (12 files)
- All test files in `__tests__` directories updated to use `@/` imports

## Benefits
- **Maintainability**: Easier to move files without breaking imports
- **Readability**: Clear indication of module location
- **Consistency**: Uniform import style across the codebase
- **Standards Compliance**: Follows CLAUDE.md Import Path Standards

## Verification
✅ All quality checks passed:
- TypeScript type-check: **passed**
- Biome lint: **passed**
- Unit tests: **28 tests passed**
- E2E tests: **100+ tests passed**

## Test Plan
- [x] Run `npm run type-check` - no errors
- [x] Run `npm run lint` - no warnings
- [x] Run `npm run test:unit` - all tests passed
- [x] Run `npm run test:e2e` - all tests passed
- [x] Verify no relative imports remain: `grep -r "from [\"']\.\./" packages/core/src` - no matches

## Related
Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)