### PR TITLE
Web: Search/Browse UX improvements; robust Ollama embeddings handling

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -8,6 +8,7 @@ import { CreateEditEmbedding } from '@/components/CreateEditEmbedding'
 import { ProviderManagement } from '@/components/ProviderManagement'
 import { ModelMigration } from '@/components/ModelMigration'
 import { EmbeddingDetailModal } from '@/components/EmbeddingDetailModal'
+import { apiClient } from '@/services/api'
 import type { Embedding, SearchResult } from '@/types/api'
 
 // Create a client
@@ -70,9 +71,25 @@ function AppContent() {
     window.location.hash = tab
   }
 
-  const handleSearchResultSelect = (result: SearchResult) => {
-    console.log('Selected search result:', result)
-    // You could open a modal or navigate to a detail view here
+  const handleSearchResultSelect = async (result: SearchResult) => {
+    // Optimistically open with minimal data, then hydrate with full embedding
+    setSelectedEmbedding({
+      id: result.id,
+      uri: result.uri,
+      text: result.text,
+      model_name: result.model_name,
+      embedding: [],
+      created_at: result.created_at,
+      updated_at: result.updated_at,
+    })
+    setIsDetailModalOpen(true)
+
+    try {
+      const full = await apiClient.getEmbedding(result.uri, result.model_name)
+      setSelectedEmbedding(full)
+    } catch (e) {
+      console.error('Failed to load embedding details from search result:', e)
+    }
   }
 
   const handleEmbeddingSelect = (embedding: Embedding) => {

--- a/packages/web/src/components/EmbeddingDetailModal.tsx
+++ b/packages/web/src/components/EmbeddingDetailModal.tsx
@@ -77,10 +77,14 @@ export function EmbeddingDetailModal({ embedding, open, onClose }: EmbeddingDeta
             <div>
               <span className="text-xs text-muted-foreground">First 10 values:</span>
               <Card className="mt-1 p-3 bg-muted/30">
-                <code className="text-xs font-mono block overflow-x-auto">
-                  [{embedding.embedding.slice(0, 10).map(v => v.toFixed(6)).join(', ')}
-                  {embedding.embedding.length > 10 ? ', ...' : ''}]
-                </code>
+                {embedding.embedding.length === 0 ? (
+                  <span className="text-xs text-muted-foreground">Loading embedding vector...</span>
+                ) : (
+                  <code className="text-xs font-mono block overflow-x-auto">
+                    [{embedding.embedding.slice(0, 10).map(v => v.toFixed(6)).join(', ')}
+                    {embedding.embedding.length > 10 ? ', ...' : ''}]
+                  </code>
+                )}
               </Card>
             </div>
           </div>

--- a/packages/web/src/components/SearchInterface.tsx
+++ b/packages/web/src/components/SearchInterface.tsx
@@ -29,6 +29,17 @@ export function SearchInterface({ onResultSelect }: SearchInterfaceProps) {
   const { data: searchResults, isLoading: isSearching, error } = useSearchEmbeddings(searchParams)
   const { data: modelsData } = useModels()
 
+  // When models are loaded, set default model to the first available one if not selected yet
+  useEffect(() => {
+    if (!modelsData?.models) return
+    if (searchParams.model_name) return
+
+    const firstAvailable = modelsData.models.find((m) => m.available)
+    if (firstAvailable?.name) {
+      updateFilter('model_name', firstAvailable.name)
+    }
+  }, [modelsData, searchParams.model_name, updateFilter])
+
   // Debounced search
   useEffect(() => {
     if (!query.trim()) {
@@ -92,9 +103,8 @@ export function SearchInterface({ onResultSelect }: SearchInterfaceProps) {
               <select
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 value={searchParams.model_name || ''}
-                onChange={(e) => updateFilter('model_name', e.target.value || undefined)}
+                onChange={(e) => updateFilter('model_name', e.target.value)}
               >
-                <option value="">All Models</option>
                 {modelsData?.models
                   .filter((model) => model.available)
                   .map((model) => (

--- a/packages/web/src/services/api.ts
+++ b/packages/web/src/services/api.ts
@@ -90,8 +90,8 @@ class ApiClient {
     return this.request<EmbeddingsListResponse>(`/embeddings${query ? `?${query}` : ''}`)
   }
 
-  async getEmbedding(uri: string): Promise<Embedding> {
-    return this.request<Embedding>(`/embeddings/${encodeURIComponent(uri)}`)
+  async getEmbedding(uri: string, modelName: string): Promise<Embedding> {
+    return this.request<Embedding>(`/embeddings/${encodeURIComponent(uri)}/${encodeURIComponent(modelName)}`)
   }
 
   async getDistinctEmbeddingModels(): Promise<{ models: string[] }> {

--- a/packages/web/src/utils/eesignore.ts
+++ b/packages/web/src/utils/eesignore.ts
@@ -119,8 +119,20 @@ export async function loadEesignoreFromFiles(files: FileList): Promise<string[]>
  * Filter files based on ignore patterns
  */
 export function filterFiles(files: File[], patterns: string[]): File[] {
+  // Always exclude .gitignore and .eesignore files regardless of patterns
+  const alwaysExcluded = new Set(['.gitignore', '.eesignore'])
+
   return files.filter(file => {
     const path = (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name
+
+    // Extract the base filename for direct name checks
+    const segments = path.split("/")
+    const baseName = segments[segments.length - 1]
+
+    if (alwaysExcluded.has(baseName)) {
+      return false
+    }
+
     return !shouldIgnore(path, patterns)
   })
 }


### PR DESCRIPTION
This PR improves the Search and Browse UX and fixes embedding vector handling.

Changes:
- Web: Remove "All Models" in Search and default to first available model
- Web: Directory upload always excludes .gitignore and .eesignore
- Web: Browse supports multi-select, bulk delete, and card-click to toggle selection
- Web: Search results open detail modal; optimistic render then hydrate from GET /embeddings/{uri}/{model_name}
- Web: Detail modal shows loading while vector is empty
- Core: Ollama provider handles both /api/embeddings and /api/embed endpoints and both response shapes (embedding | embeddings[0])

Quality:
- Type-check and Biome lint pass
- No changes to biome.json

Notes:
- If embedding vectors still appear empty for embeddinggemma, please share the Ollama version and exact model tag (e.g., embeddinggemma:300m).