### PR TITLE
feat: Add org-mode to Markdown conversion with pandoc

### DIFF
--- a/packages/web/src/components/EmbeddingDetailModal.tsx
+++ b/packages/web/src/components/EmbeddingDetailModal.tsx
@@ -56,15 +56,43 @@ export function EmbeddingDetailModal({ embedding, open, onClose }: EmbeddingDeta
           <p className="text-xs text-muted-foreground mt-1">Display name: {formatUri(embedding.uri)}</p>
         </div>
 
+        {/* Conversion Information */}
+        {embedding.converted_format && (
+          <div className="p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+            <div className="flex items-center gap-2">
+              <svg className="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+              <span className="text-sm font-medium text-blue-900 dark:text-blue-100">
+                Converted from org-mode to {embedding.converted_format}
+              </span>
+            </div>
+          </div>
+        )}
+
         {/* Text Content */}
         <div>
-          <label className="text-sm font-medium text-muted-foreground">Text Content</label>
+          <label className="text-sm font-medium text-muted-foreground">
+            {embedding.converted_format ? 'Converted Content (Markdown)' : 'Text Content'}
+          </label>
           <Card className="mt-2 p-4 bg-muted/30">
             <p className="text-sm whitespace-pre-wrap break-words max-h-60 overflow-y-auto">
               {embedding.text}
             </p>
           </Card>
         </div>
+
+        {/* Original Content */}
+        {embedding.original_content && (
+          <div>
+            <label className="text-sm font-medium text-muted-foreground">Original Content (Org-mode)</label>
+            <Card className="mt-2 p-4 bg-muted/30">
+              <p className="text-sm whitespace-pre-wrap break-words max-h-60 overflow-y-auto font-mono">
+                {embedding.original_content}
+              </p>
+            </Card>
+          </div>
+        )}
 
         {/* Embedding Vector Information */}
         <div>

--- a/packages/web/src/components/EmbeddingList.tsx
+++ b/packages/web/src/components/EmbeddingList.tsx
@@ -216,14 +216,21 @@ export function EmbeddingList({ onEmbeddingSelect, onEmbeddingEdit }: EmbeddingL
                           className="mt-1"
                         />
                         <div className="flex-1 min-w-0">
-                        <h4 className="font-medium truncate" title={embedding.uri}>
-                          {formatUri(embedding.uri)}
-                        </h4>
-                        <div className="flex gap-4 text-sm text-muted-foreground mt-1">
-                          <span>ID: {embedding.id}</span>
-                          <span>Model: {embedding.model_name}</span>
-                          <span>Created: {formatDate(embedding.created_at)}</span>
-                        </div>
+                          <div className="flex items-center gap-2">
+                            <h4 className="font-medium truncate" title={embedding.uri}>
+                              {formatUri(embedding.uri)}
+                            </h4>
+                            {embedding.converted_format && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                                org → {embedding.converted_format}
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex gap-4 text-sm text-muted-foreground mt-1">
+                            <span>ID: {embedding.id}</span>
+                            <span>Model: {embedding.model_name}</span>
+                            <span>Created: {formatDate(embedding.created_at)}</span>
+                          </div>
                         </div>
                       <div className="flex gap-2 ml-4">
                         <Button

--- a/packages/web/src/types/api.ts
+++ b/packages/web/src/types/api.ts
@@ -6,6 +6,8 @@ export interface Embedding {
   text: string
   model_name: string
   embedding: number[]
+  original_content?: string
+  converted_format?: string
   created_at: string
   updated_at: string
 }
@@ -63,6 +65,8 @@ export interface SearchResult {
   text: string
   model_name: string
   similarity: number
+  original_content?: string
+  converted_format?: string
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
## Summary

This PR implements automatic conversion of org-mode files to Markdown when uploading to EES. The conversion is performed using pandoc and preserves the original org-mode content for reference.

### Key Features

- **Automatic org-mode detection and conversion** - Files with `.org` extension are automatically converted to Markdown using pandoc
- **Original content preservation** - Both the converted Markdown and original org-mode text are stored in the database
- **Graceful degradation** - If pandoc is unavailable, the system falls back to using the original org-mode content
- **Web UI support** - Dashboard displays conversion badges and allows viewing both converted and original content
- **Comprehensive testing** - 43 new tests covering unit tests and E2E scenarios

### Changes Made

#### Core Functionality
- **New pandoc converter module** (`packages/core/src/shared/lib/pandoc-converter.ts`)
  - `convertOrgToMarkdown()` - Converts org-mode content to Markdown using pandoc
  - `isPandocAvailable()` - Checks if pandoc is installed and available
  - Tagged error types for conversion failures
  
- **Enhanced file processor** (`packages/core/src/shared/lib/file-processor.ts`)
  - Detects `.org` files and applies automatic conversion
  - Stores both `original_content` and `converted_format` metadata
  - Gracefully handles pandoc unavailability

#### Database Schema
- **New columns in embeddings table**:
  - `original_content TEXT` - Stores the original org-mode content
  - `converted_format TEXT` - Indicates the conversion format (e.g., "markdown")

#### Infrastructure
- **Nix flake** - Added pandoc to buildInputs and version display in shellHook
- **Dockerfile** - Added pandoc installation in production stage
- **CI/CD** - Added pandoc installation step in GitHub Actions workflow

#### Testing
- **Unit tests** (`pandoc-converter.test.ts`) - 19 tests covering error handling and conversion functionality
- **Integration tests** (`file-processor.test.ts`) - 10 new tests for org-mode file processing
- **E2E tests** (`org-file-upload.e2e.test.ts`) - 14 tests covering various org-mode upload scenarios
- All tests handle graceful degradation when pandoc is unavailable

#### Web UI
- **API types** - Added `original_content` and `converted_format` fields to `Embedding` and `SearchResult` interfaces
- **EmbeddingDetailModal** - Displays conversion info banner, converted content, and original content sections
- **EmbeddingList** - Shows conversion badge ("org → markdown") next to converted embeddings

### Technical Details

**Supported org-mode features:**
- Headings and subheadings
- Text formatting (bold, italic)
- Lists (bullet points, numbered, checkboxes)
- Tables
- Code blocks
- Links (external and internal)
- Special characters and Unicode

**Architecture:**
- Uses Effect-ts for composable error handling
- Pandoc subprocess spawned with stdin/stdout pipes for conversion
- UTF-8 encoding support for international characters
- Proper signal handling and process cleanup

### Testing

All tests pass successfully:
```bash
npm run test:run          # All unit and integration tests
npm run type-check        # TypeScript compilation
npm run lint              # Code quality checks
npm run build             # Production build
```

### Breaking Changes

None - the new columns are optional and backward compatible.

### Migration Guide

No migration required. Existing embeddings without conversion metadata will continue to work normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)