### PR TITLE
fix: resolve process.env access error in browser environment

### DIFF
--- a/packages/web/src/services/api.ts
+++ b/packages/web/src/services/api.ts
@@ -530,11 +530,11 @@ const createMockApiClient = () => ({
 })
 
 // Use mock in Storybook environment or when STORYBOOK_MOCK is set
-const isStorybook = typeof window !== 'undefined' && 
-  (window.location?.pathname?.includes('storybook') || 
+const isStorybook = typeof window !== 'undefined' &&
+  (window.location?.pathname?.includes('storybook') ||
    window.location?.hostname?.includes('localhost:6006') ||
    window.location?.hostname?.includes('localhost:6007') ||
-   process.env.STORYBOOK_MOCK === 'true')
+   import.meta.env.VITE_STORYBOOK_MOCK === 'true')
 
 export const apiClient = isStorybook ? createMockApiClient() : new ApiClient()
 

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_STORYBOOK_MOCK?: string
+  readonly VITE_API_BASE_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
Fixes the runtime error: `Uncaught ReferenceError: process is not defined at api.ts:537`

This error occurs when the web application or Storybook tries to access `process.env` in the browser environment.

## Changes
- **Replace `process.env` with `import.meta.env`** - Use Vite's environment variable access pattern
- **Add `vite-env.d.ts`** - Provide TypeScript type definitions for `import.meta.env`
- **Define environment variables** - Add `VITE_STORYBOOK_MOCK` and `VITE_API_BASE_URL` to ImportMetaEnv interface

## Root Cause
Vite-based applications run in the browser where `process` is not available. Vite provides `import.meta.env` as the proper way to access environment variables in client-side code.

## Test plan
- [x] TypeScript type checking passes
- [x] Linting passes
- [x] No runtime errors in browser console
- [x] Storybook loads without errors
- [x] Web application starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)