### PR TITLE
feat: Add task type support and deterministic visualization

### DIFF
--- a/packages/web/src/components/UploadDirectoryManagement.tsx
+++ b/packages/web/src/components/UploadDirectoryManagement.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { FolderOpen, FolderPlus, RefreshCw, Trash2, CheckCircle, AlertCircle, Search } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
+import { Badge } from '@/components/ui/Badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card'
 import { DirectoryPickerModal } from '@/components/DirectoryPickerModal'
 import {
@@ -457,6 +458,15 @@ export function UploadDirectoryManagement() {
                         <p className="text-sm text-muted-foreground mt-1">
                           {directory.description}
                         </p>
+                      )}
+                      {directory.task_types && directory.task_types.length > 0 && (
+                        <div className="flex flex-wrap gap-1 mt-2">
+                          {directory.task_types.map((taskType) => (
+                            <Badge key={taskType} variant="outline" className="text-xs">
+                              {taskType}
+                            </Badge>
+                          ))}
+                        </div>
                       )}
                     </div>
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

This PR adds comprehensive task type support for embeddings and improves visualization reproducibility through deterministic seeding.

### Task Type Support
- ✅ Multiple task types can be selected when creating embeddings
- ✅ Each task type creates a separate embedding for the same document
- ✅ Task types are stored in database with composite unique index (uri, model_name, task_type)
- ✅ Upload directories can specify default task types
- ✅ Task types displayed in UI (embedding list, directory list, detail modal)

### Deterministic Visualization
- ✅ Fixed the issue where visualization plots changed position on every execution
- ✅ Added seeded random number generators (mulberry32) for t-SNE, UMAP, and k-means
- ✅ User-friendly seed mode selection: Fixed (42), Random, Custom
- ✅ Display of last used seed for reproducibility

### API & Database Changes
- Added `task_type` column to `embeddings` table
- Added `task_types` column to `upload_directories` table
- Updated composite unique index: `(uri, model_name, task_type)`
- Fixed upload directory endpoints to handle task_types parameter
- Added seed mode support to visualization API

### UI Enhancements
- Task type badges in embedding list view
- Task type display in embedding detail modal
- Task type display in directory list
- Seed mode controls (only for t-SNE and UMAP)
- Last used seed display for reproducibility

## Test plan

- [ ] Register a directory with multiple task types selected
- [ ] Verify multiple embeddings are created per file (one per task type)
- [ ] Check task types are displayed in all relevant views
- [ ] Test visualization with different seed modes (fixed/random/custom)
- [ ] Verify same seed produces identical visualization results
- [ ] Run type-check and linting

## Related Issues

Implements task type support similar to embeddinggemma's design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)