### PR TITLE
refactor: simplify semantic search to use single task type selector

### DIFF
--- a/packages/web/src/hooks/useEmbeddings.ts
+++ b/packages/web/src/hooks/useEmbeddings.ts
@@ -29,6 +29,7 @@ export const QUERY_KEYS = {
     query.query,
     query.model_name,
     query.query_task_type,
+    query.document_task_type,
     query.query_title,
     query.limit,
     query.threshold,


### PR DESCRIPTION
## Summary

Simplifies the Semantic Search interface by consolidating the separate "Query Task Type" and "Document Task Type" selectors into a single "Task Type" selector, since they are always used with matching values in practice.

## Changes

### UI Simplification
- **Before**: Two separate selectors for Query Task Type and Document Task Type
- **After**: Single unified "Task Type" selector with clearer label "Task type for both query and documents"

### Implementation Details

1. **SearchInterface.tsx**:
   - Updated filters from `query_task_type` and `document_task_type` to single `task_type` field
   - Added conversion logic to map the single `task_type` to both API parameters for backward compatibility
   - Merged two separate select elements into one
   - Updated all references to use the unified `task_type` field

2. **useEmbeddings.ts**:
   - Added `document_task_type` to search query cache key to ensure proper cache invalidation

### Code Changes

**Filter State (Before)**:
```typescript
query_task_type: undefined as TaskType | undefined,
document_task_type: undefined as TaskType | undefined,
```

**Filter State (After)**:
```typescript
task_type: undefined as TaskType | undefined,
```

**API Conversion Logic**:
```typescript
const searchApiParams = {
  ...searchParams,
  query_task_type: searchParams.task_type,
  document_task_type: searchParams.task_type,
}
```

## Benefits

- ✅ **Simpler UI**: Reduces cognitive load by removing redundant selectors
- ✅ **Clearer intent**: Single selector makes it obvious that the same task type applies to both query and documents
- ✅ **Better UX**: Users no longer need to manage two separate settings that should always match
- ✅ **Backward compatible**: Still passes both parameters to the API as expected

## Testing

- [x] Type checking passes (`npm run type-check`)
- [x] Linting passes (`npm run lint`)
- [x] Verified UI shows single selector with proper behavior
- [x] Confirmed API receives both query_task_type and document_task_type parameters

## Screenshots

### Before
Two separate task type selectors:
- Query Task Type selector with help text "How to format your query"
- Document Task Type selector with help text "Which documents to search"

### After
Single unified task type selector:
- Task Type selector with help text "Task type for both query and documents"

## Related Issues

Addresses user feedback: "Semantic Search で Query Task Type と Document Task Type は常に一致するような使われ方をするので Task Type としてまとめて一つだけ選択するようにしてください"

🤖 Generated with [Claude Code](https://claude.com/claude-code)