### PR TITLE
fix: prevent layout shift in visualization hover tooltip

### DIFF
--- a/packages/web/src/components/EmbeddingVisualization.tsx
+++ b/packages/web/src/components/EmbeddingVisualization.tsx
@@ -1385,20 +1385,20 @@ export function EmbeddingVisualization() {
                         ✨ This is your input text
                       </div>
                     )}
-                    {hoverInfo.originalDocument ? (
-                      <div>
-                        <span className="text-xs font-medium text-muted-foreground uppercase">Document</span>
-                        <div className="mt-1 p-3 bg-muted/30 rounded border max-h-32 overflow-y-auto">
+                    <div>
+                      <span className="text-xs font-medium text-muted-foreground uppercase">Document</span>
+                      <div className="mt-1 p-3 bg-muted/30 rounded border h-32 overflow-y-auto">
+                        {hoverInfo.originalDocument ? (
                           <p className="text-xs whitespace-pre-wrap break-words">
                             {hoverInfo.originalDocument}
                           </p>
-                        </div>
+                        ) : (
+                          <p className="text-xs text-muted-foreground italic">
+                            Hover for {hoverDelayMs}ms to load document...
+                          </p>
+                        )}
                       </div>
-                    ) : (
-                      <div className="text-xs text-muted-foreground italic">
-                        Hover for {hoverDelayMs}ms to load document...
-                      </div>
-                    )}
+                    </div>
                   </div>
                 </div>
               )}
@@ -1470,18 +1470,20 @@ export function EmbeddingVisualization() {
                         ✨ This is your input text
                       </div>
                     )}
-                    {hoverInfo.originalDocument ? (
+                    {!hoverInfo.isInputPoint && (
                       <div>
                         <span className="text-xs font-medium text-muted-foreground uppercase">Document</span>
-                        <div className="mt-1 p-3 bg-muted/30 rounded border max-h-32 overflow-y-auto">
-                          <p className="text-xs whitespace-pre-wrap break-words">
-                            {hoverInfo.originalDocument}
-                          </p>
+                        <div className="mt-1 p-3 bg-muted/30 rounded border h-32 overflow-y-auto">
+                          {hoverInfo.originalDocument ? (
+                            <p className="text-xs whitespace-pre-wrap break-words">
+                              {hoverInfo.originalDocument}
+                            </p>
+                          ) : (
+                            <p className="text-xs text-muted-foreground italic">
+                              Hover for {hoverDelayMs}ms to load document...
+                            </p>
+                          )}
                         </div>
-                      </div>
-                    ) : !hoverInfo.isInputPoint && (
-                      <div className="text-xs text-muted-foreground italic">
-                        Hover for {hoverDelayMs}ms to load document...
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
Fixed the height jumping issue in the embedding visualization hover tooltip that occurred when the original document content was loaded after the hover delay.

## Problem
When hovering over a point in the visualization:
1. Initially shows: "Hover for Xms to load document..." (small height)
2. After delay: Document content loads (larger height with scrollable area)
3. This caused the tooltip to **jump/shift position**, creating a jarring UX

## Solution
Implemented a **fixed-height container** for the document display area:
- Container height is always `h-32` (128px) regardless of loading state
- Loading message appears inside the fixed-height container
- Document content appears in the same fixed-height container with `overflow-y-auto`
- Tooltip position remains stable during the entire interaction

## Changes

### Before
```tsx
{hoverInfo.originalDocument ? (
  <div>
    <span>Document</span>
    <div className="max-h-32 overflow-y-auto"> {/* Variable height */}
      <p>{hoverInfo.originalDocument}</p>
    </div>
  </div>
) : (
  <div>Hover for Xms to load document...</div> {/* Different height */}
)}
```

### After
```tsx
<div>
  <span>Document</span>
  <div className="h-32 overflow-y-auto"> {/* Fixed height */}
    {hoverInfo.originalDocument ? (
      <p>{hoverInfo.originalDocument}</p>
    ) : (
      <p>Hover for Xms to load document...</p>
    )}
  </div>
</div>
```

## Technical Details
- **Files changed**: `EmbeddingVisualization.tsx`
- **Lines affected**: 
  - 3D view tooltip: 1388-1401
  - 2D view tooltip: 1473-1488
- **CSS change**: `max-h-32` → `h-32` for consistent height
- **Structure**: Always render container, conditionally render content inside

## Impact
✅ **Improved UX**: No more jarring layout shifts during hover  
✅ **Stable positioning**: Tooltip stays in the same position while loading  
✅ **Consistent experience**: Same behavior in both 2D and 3D views  
✅ **Maintains functionality**: Scrolling still works for long documents

## Test Plan
- [x] Type-check passes
- [x] Lint passes
- [ ] Manual testing: Hover over visualization points
- [ ] Verify: Tooltip doesn't shift when document loads
- [ ] Verify: Long documents still scroll properly
- [ ] Test in both 2D and 3D visualization modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)