### PR TITLE
fix: remove duplicate 'All Models' option in Browse filter

### DIFF
--- a/packages/web/src/components/EmbeddingList.tsx
+++ b/packages/web/src/components/EmbeddingList.tsx
@@ -168,7 +168,6 @@ export function EmbeddingList({ onEmbeddingSelect, onEmbeddingEdit }: EmbeddingL
                   label: model,
                 })) || []),
               ]}
-              placeholder="All Models"
             />
             <FormSelect
               label="Items per page"


### PR DESCRIPTION
## Summary

Fixed a bug where "All Models" appeared twice in the Filter by Model dropdown on the Browse page.

## Problem

The Filter by Model select dropdown was showing two identical "All Models" options:
1. One from the explicitly defined option in the `options` array
2. One automatically generated from the `placeholder` prop

## Root Cause

The `FormSelect` component automatically adds a placeholder option (`<option value="">{placeholder}</option>`) when the `placeholder` prop is provided.

In `EmbeddingList.tsx`, we were passing:
- An explicit option: `{ value: '', label: 'All Models' }` in the options array
- A placeholder prop: `placeholder="All Models"`

This resulted in two separate `<option>` elements with the same text.

## Solution

Removed the `placeholder` prop from the `FormSelect` component call, keeping only the explicit option in the `options` array.

## Changes

- `packages/web/src/components/EmbeddingList.tsx`
  - Removed `placeholder="All Models"` from FormSelect (line 171)
  - Kept the explicit `{ value: '', label: 'All Models' }` option

## Testing

- ✅ Type checking passed
- ✅ Linting passed
- ✅ Only one "All Models" option appears in the dropdown
- ✅ Filter functionality works correctly

## Before/After

**Before**: Two "All Models" options displayed  
**After**: One "All Models" option displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)