### PR TITLE
fix: use placeholder for 'All Models' to show proper default text

### DIFF
--- a/packages/web/src/components/EmbeddingList.tsx
+++ b/packages/web/src/components/EmbeddingList.tsx
@@ -161,13 +161,11 @@ export function EmbeddingList({ onEmbeddingSelect, onEmbeddingEdit }: EmbeddingL
               label="Filter by Model"
               value={filters.modelName}
               onChange={(value) => handleFilterChange('modelName', value)}
-              options={[
-                { value: '', label: 'All Models' },
-                ...(distinctModels?.models.map((model) => ({
-                  value: model,
-                  label: model,
-                })) || []),
-              ]}
+              options={distinctModels?.models.map((model) => ({
+                value: model,
+                label: model,
+              })) || []}
+              placeholder="All Models"
             />
             <FormSelect
               label="Items per page"


### PR DESCRIPTION
## Summary

Improved the Filter by Model dropdown to display "All Models" as the default text using FormSelect's placeholder feature, avoiding the generic "Select an option" text.

## Problem

After PR #202 removed the duplicate "All Models" option by removing the `placeholder` prop, the dropdown now shows the FormSelect's default placeholder text "Select an option" when no filter is applied, which is not user-friendly.

## Solution

Use the `placeholder` prop properly by:
1. Removing the explicit `{ value: '', label: 'All Models' }` option from the array
2. Adding `placeholder="All Models"` to the FormSelect component
3. Let FormSelect automatically generate the placeholder option

This leverages FormSelect's built-in functionality where it creates an `<option value="">` with the placeholder text when the prop is provided.

## Changes

**File**: `packages/web/src/components/EmbeddingList.tsx`

- Removed explicit `{ value: '', label: 'All Models' }` from options array
- Added `placeholder="All Models"` prop to FormSelect
- Simplified options to only include actual model names

## Benefits

✅ Displays "All Models" by default (not "Select an option")  
✅ No duplicate options  
✅ Cleaner code  
✅ Uses FormSelect's intended API  

## Testing

- ✅ Type checking passed
- ✅ Linting passed
- ✅ Only one "All Models" option appears
- ✅ Default text shows "All Models" instead of "Select an option"
- ✅ Filter functionality works correctly

## Behavior

- **Initial state**: Shows "All Models" (no filter applied)
- **After selecting a model**: Shows selected model name
- **After selecting "All Models"**: Clears filter and shows all models

🤖 Generated with [Claude Code](https://claude.com/claude-code)