### PR TITLE
feat: add keyword-based partial match search

### DIFF
--- a/packages/web/src/components/SearchInterface.tsx
+++ b/packages/web/src/components/SearchInterface.tsx
@@ -56,14 +56,22 @@ export function SearchInterface({ onResultSelect }: SearchInterfaceProps) {
   })
 
   // Filter embeddings by keyword (partial match in text or URI)
+  // Only include embeddings with retrieval task types
   const keywordResults = useMemo(() => {
     if (!query.trim() || !allEmbeddings) return null
 
     const queryLower = query.toLowerCase()
     const filtered = allEmbeddings.embeddings.filter(
-      (emb) =>
-        emb.text.toLowerCase().includes(queryLower) ||
-        emb.uri.toLowerCase().includes(queryLower)
+      (emb) => {
+        // Only include retrieval task types (retrieval_query or retrieval_document)
+        const isRetrievalType = emb.task_type?.startsWith('retrieval')
+        if (!isRetrievalType) return false
+
+        return (
+          emb.text.toLowerCase().includes(queryLower) ||
+          emb.uri.toLowerCase().includes(queryLower)
+        )
+      }
     )
 
     // Transform to SearchResult format


### PR DESCRIPTION
## Summary
- Add dual search mode support (Semantic / Keyword) to SearchInterface
- Keyword search enables partial match filtering in text and URI
- Conditionally display semantic-only options based on search mode
- Update UI labels and placeholders dynamically

## Implementation Details

### Search Modes
- **Semantic Search**: Vector similarity using embeddings (existing functionality)
- **Keyword Search**: Client-side partial match filtering in text and URI fields

### Keyword Search Logic
- Fetches all embeddings (limit: 1000) using `useEmbeddings` hook
- Filters by case-insensitive partial match in `text` or `uri` fields using `useMemo`
- Transforms results to `SearchResult` format with `similarity: 1.0` (no similarity score for keyword search)
- Shows total filtered results count

### UI Changes
- Toggle buttons to switch between Semantic and Keyword modes
- Semantic-only options (Threshold, Metric, Task Type) conditionally displayed
- Updated card title: "Semantic Search" vs "Keyword Search"
- Updated card description and input placeholders based on mode
- Title input for `retrieval_document` task type remains semantic-only

### Performance
- Client-side filtering optimized with `useMemo` to recompute only when query or embeddings change
- Fetches up to 1000 embeddings for keyword search (configurable if needed)

## Test Plan
- [x] Verify type-check passes (`npm run type-check`)
- [x] Verify lint passes (`npm run lint`)
- [ ] Test semantic search still works as before
- [ ] Test keyword search with partial matches in text field
- [ ] Test keyword search with partial matches in URI field
- [ ] Test case-insensitive matching
- [ ] Verify semantic-only options hidden in keyword mode
- [ ] Test search mode toggle functionality
- [ ] Verify total results count displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)