### PR TITLE
fix: preserve front matter when switching tabs

### DIFF
--- a/packages/web/src/components/EmbeddingDetailModal.tsx
+++ b/packages/web/src/components/EmbeddingDetailModal.tsx
@@ -140,8 +140,8 @@ export function EmbeddingDetailModal({ embedding, open, onClose }: EmbeddingDeta
           </div>
 
           <Card className="p-4 bg-muted/30">
-            {activeTab === 'markdown' ? (
-              renderMarkdown && isMarkdownContent ? (
+            <div className={activeTab === 'markdown' ? 'block' : 'hidden'}>
+              {renderMarkdown && isMarkdownContent ? (
                 <div className="max-h-96 overflow-y-auto">
                   <MarkdownRenderer content={embedding.text} />
                 </div>
@@ -149,11 +149,14 @@ export function EmbeddingDetailModal({ embedding, open, onClose }: EmbeddingDeta
                 <p className="text-sm whitespace-pre-wrap break-words max-h-96 overflow-y-auto">
                   {embedding.text}
                 </p>
-              )
-            ) : (
-              <p className="text-sm whitespace-pre-wrap break-words max-h-96 overflow-y-auto font-mono">
-                {embedding.original_content}
-              </p>
+              )}
+            </div>
+            {hasOriginalContent && (
+              <div className={activeTab === 'original' ? 'block' : 'hidden'}>
+                <p className="text-sm whitespace-pre-wrap break-words max-h-96 overflow-y-auto font-mono">
+                  {embedding.original_content}
+                </p>
+              </div>
             )}
           </Card>
         </div>


### PR DESCRIPTION
## Summary
Fixed an issue where the front matter table disappeared when switching between tabs in the Embedding Detail Modal.

## Problem
When users switched between "Converted (Markdown)" and "Original (Org-mode)" tabs, the front matter table would disappear and not reappear when switching back.

## Root Cause
- Tab switching was using conditional rendering (`activeTab === 'markdown' ? ... : ...`)
- This caused the `MarkdownRenderer` component to be completely unmounted when switching away
- Component remount reset the `frontMatterData` state
- Front matter had to be re-parsed each time, but the state was lost

## Solution
- Changed from conditional rendering to CSS-based visibility toggle
- Use `className={activeTab === 'markdown' ? 'block' : 'hidden'}` instead
- Components stay mounted, preserving their state
- Front matter data is now preserved when switching between tabs

## Changes
- Modified `EmbeddingDetailModal.tsx` to use display block/hidden instead of conditional rendering
- Both tab contents are now always mounted, only visibility is toggled
- No changes to `MarkdownRenderer` component needed

## Benefits
- **Better UX**: Front matter table remains visible when switching back to markdown tab
- **Performance**: No need to re-parse front matter when switching tabs
- **State preservation**: All component state is maintained during tab switches

## Testing
- [x] Front matter table displays correctly on initial render
- [x] Front matter persists when switching to original tab and back
- [x] No console errors or warnings
- [x] Type-check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)