### PR TITLE
feat: increase Text Content input area height in Create form

### DIFF
--- a/packages/web/src/components/CreateEditEmbedding.tsx
+++ b/packages/web/src/components/CreateEditEmbedding.tsx
@@ -181,7 +181,7 @@ export function CreateEditEmbedding({ editingEmbedding, onEditComplete }: Create
             <div>
               <label className="text-sm font-medium">Text Content</label>
               <textarea
-                className="flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex min-h-[400px] max-h-[600px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-y"
                 placeholder="Enter the text content to generate embedding for..."
                 value={text}
                 onChange={(e) => setText(e.target.value)}


### PR DESCRIPTION
## Summary
Significantly increased the height of the Text Content input area in the Create form to better reflect its importance as the main content field.

## Problem
The previous Text Content textarea had a minimum height of only 120px, which was too small for the primary input field where users enter their content. This made it difficult to work with longer texts and review content before creating embeddings.

## Changes
- **Increased min-height**: 120px → 400px (3.3x larger)
- **Added max-height**: Set to 600px to prevent excessive expansion
- **Added resize capability**: Users can now manually adjust height with `resize-y` class

## Visual Impact

**Before:**
- Text area: 120px minimum height
- Difficult to input/review longer content
- Required scrolling within a small area

**After:**
- Text area: 400px minimum height (up to 600px max)
- Much easier to input and review content
- User-adjustable height for flexibility
- Better visual emphasis on the main content field

## Benefits
- **Better UX**: More space for the primary input makes content entry easier
- **Improved readability**: Users can see more of their content at once
- **Flexibility**: Resizable textarea allows users to customize to their needs
- **Appropriate emphasis**: The main content field now has visual weight matching its importance

## Testing
- [x] Textarea displays with new height (400px minimum)
- [x] User can resize textarea vertically
- [x] Max height constraint (600px) works correctly
- [x] Form submission works correctly
- [x] Type-check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)